### PR TITLE
Fill out TxValue interface

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,3 +1,4 @@
+import { StdFee, StdSignature } from './auth';
 import { MsgSend, MsgMultiSend } from './bank';
 
 /** @TODO document */
@@ -14,6 +15,10 @@ export interface Tx {
 
 /** @TODO document */
 export interface TxValue {
+    msg: Msg[];
+    fee: StdFee;
+    signatures: StdSignature[];
+    memo: string;
 }
 
 /** @TODO document */


### PR DESCRIPTION
We use these properties when parsing transactions:

https://github.com/iov-one/iov-core/pull/1284/files#diff-cc1f2c86c6d5feca03106c7a8d466721R95-R127

Our current workaround is just to extend the `Tx` type ourselves:

https://github.com/iov-one/iov-core/pull/1284/files#diff-f71a0171c874a25feeea1a9a94f3f185R1-R11